### PR TITLE
feat: adds new event detail page

### DIFF
--- a/src/components/tables/eventsTableCustom.vue
+++ b/src/components/tables/eventsTableCustom.vue
@@ -29,7 +29,7 @@ const { getList: eventsList } = storeToRefs(useEvents());
           <div class="flex-table-body-td">
             <router-link
               tag="v-btn"
-              :to="{ name: 'DetailtEvent', params: { id: item.id } }"
+              :to="{ name: 'EventDetails', params: { id: item.id } }"
             >
               <v-btn size="small" color="primary" type="submit" variant="text"
                 >Detalhes</v-btn

--- a/src/router/eventsRoutes.ts
+++ b/src/router/eventsRoutes.ts
@@ -17,6 +17,16 @@ const eventsRoutes = {
       component: () => import("@/views/events/Detail.vue"),
     },
     {
+      name: "EventDetails",
+      path: "/events/details/:id",
+      component: () => import("@/views/events/EventDetails.vue"),
+      beforeEnter: (to: any) => {
+        if (!to.params?.id) {
+          return { name: 'dashboard' };
+        }
+      }
+    },
+    {
       name: "CreateEvent",
       path: "/events/Adicionar",
       component: () => import("@/views/events/Detail.vue"),

--- a/src/stores/eventStore.ts
+++ b/src/stores/eventStore.ts
@@ -132,7 +132,8 @@ export const useEvents = defineStore("events", () => {
       state.volunteersPresent.find(
         (element) => element.id == authStore.user.id
       ) == null;
-    const events = await repository.getEvents("");
+    // ToDo: Questionable whether this is needed or not. I need more context over why we are doing 1+n requests here.
+    const events = await repository.getEvents(""); 
     events.result.forEach(addIfNotExists);
     state.isLoading = false;
   };

--- a/src/views/events/EventDetails.vue
+++ b/src/views/events/EventDetails.vue
@@ -1,0 +1,353 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, reactive, ref } from "vue";
+
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
+
+import UiParentCard from "@/components/shared/UiParentCard.vue";
+
+import { storeToRefs } from 'pinia';
+import { useEvents } from "@/stores/eventStore";
+
+const eventStore = useEvents();
+const { 
+  isLoading, 
+  getEvent: event,
+  getNumberConfirmed: confirmedVolunteers,
+  volunteersPresent: eventVolunteers,
+} = storeToRefs(eventStore);
+const currentRoute = router.currentRoute.value;
+
+interface EventDetailsDataProps {
+  tab: string;
+}
+
+const data: EventDetailsDataProps = reactive({
+  tab: 'tab-1',
+})
+
+const width = ref(window.innerWidth)
+
+const isMobile = computed(() => {
+  return width.value < 960;
+})
+
+const tabsDirection = computed(() => {
+  return isMobile.value ? 'vertical' : 'horizontal'
+});
+
+const setWindowWidth = () => {
+  width.value = window.innerWidth;
+}
+
+const eventDate = (date: any) => {
+  if (!date) return '';
+  const newDate = new Date(date)
+  let dd = newDate.getDate();
+  let mm = newDate.getMonth() + 1;
+  let dayOfMonth = dd < 10 ? `0${dd}` : dd.toString();
+  let month = mm < 10 ? `0${mm}` : mm.toString();
+  return `${dayOfMonth}/${month}`
+}
+
+const eventHour = (date: any) => {
+  if (!date) return '';
+  const newHour = new Date(date)
+  let hh = newHour.getHours();
+  let mm = newHour.getMinutes();
+  let hours = hh < 10 ? `0${hh}` : hh.toString();
+  let minutes = mm < 10 ? `0${mm}` : mm.toString();
+  return `${hours}:${minutes}`
+}
+
+onMounted(async () => {
+  window.addEventListener('resize', setWindowWidth);
+  await eventStore.getById(currentRoute.params.id);
+});
+
+onUnmounted(async () => {
+  window.removeEventListener('resize', setWindowWidth);
+});
+</script>
+
+<template>
+  <div class="event-details-view">
+    <div v-if="isLoading" class="loading" />
+    <UiParentCard title="Eventos">
+      <div class="rounded-md outlined-card">
+        <div class="description-tab">
+          <div class="description-container">
+            <div class="description-name-container">
+              <span class="text-md-h6">{{ event?.name }}</span>
+              <span class="text-body-1">{{ event?.city }}</span>
+            </div>
+
+            <div class="description-details-container">
+              <div class="description-details-container__item">
+                <v-icon icon="mdi-calendar-month-outline" />
+                <span class="text-md-h5 mt-1">
+                  {{ eventDate(event?.happenAt)}}
+                </span>
+                <span class="text-body-1">
+                  Dia
+                </span>
+              </div>
+              <div class="description-details-container__item">
+                <v-icon icon="mdi-calendar-clock" />
+                <span class="text-md-h5 mt-1">
+                  {{ eventHour(event?.happenAt)}}
+                </span>
+                <span class="text-body-1">
+                  Hora
+                </span>
+              </div>
+              <div class="description-details-container__item">
+                <v-icon icon="mdi-account-check-outline" />
+                <span class="text-md-h5 mt-1">
+                  {{ confirmedVolunteers }}/ {{ event?.occupancy }}
+                </span>
+                <span class="text-body-1">
+                  Confirmados
+                </span>
+              </div>
+            </div>
+
+            <div class="description-actions-container">
+              <v-btn size="small"
+                     color="primary"
+                     class="mr-3">
+                Participar
+              </v-btn>
+            </div>
+
+          </div>
+
+          <div class="tabs-container" :class="{'mobile': isMobile }">
+            <v-tabs
+              v-model="data.tab"
+              color="primary"
+              :direction="tabsDirection"
+              height="30"
+            >
+              <v-tab prepend-icon="mdi-account-circle-outline" text="Informações" value="tab-1" />
+              <v-tab prepend-icon="mdi-heart-outline" text="Confirmados" value="tab-2" />
+              <v-tab prepend-icon="mdi-account-multiple-outline" text="Coordenadores" value="tab-3" />
+            </v-tabs>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-5 rounded-md outlined-card">
+        <v-window v-model="data.tab" class="rounded-md">
+          <v-window-item value="tab-1">
+            <v-card flat>
+              <v-card-text>
+                <p class="text-md-h3 mb-3">Informações</p>
+                <p class="text-body-1 mb-4">{{ event?.description }}</p>
+                <p class="icon-label text-body-1 mb-2">
+                  <v-icon icon="mdi-progress-check" />
+                  <span class="text-body-1 font-weight-semibold ml-3">{{ event?.status }}</span>
+                </p>
+
+                <p class="icon-label text-body-1 mb-2">
+                  <v-icon icon="mdi-arrow-collapse-all" />
+                  <span class="text-body-1 font-weight-semibold ml-3">{{ event?.meetingPoint }}</span>
+                </p>
+
+                <p class="icon-label text-body-1 mb-0">
+                  <v-icon icon="mdi-map-marker-outline" />
+                  <span class="text-body-1 font-weight-semibold ml-3">
+                    {{ event?.address }}, {{ event?.city }}
+                  </span>
+                </p>
+              </v-card-text>
+            </v-card>
+          </v-window-item>
+
+          <v-window-item value="tab-2">
+            <div class="individual-container">
+              <p class="text-md-h3 mb-5">Confirmados</p>
+              <div class="individual-card-container" v-if="eventVolunteers.length">
+                <v-card class="individual-card border" elevation="0" v-for="item in eventVolunteers" :key="item.id">
+                  <div class="info-wrapper">
+                    <v-avatar v-if="!item.photo.includes('jpg') || !item.photo.includes('png')"
+                              size="50">
+                      <img src="@/assets/images/palhaco.png" alt="user" height="50" />
+                    </v-avatar>
+                    <v-avatar size="50" v-else>
+                      <img :src="item.photo" height="50" />
+                    </v-avatar>
+                    <div class="info-wrapper-name ml-2">
+                      <v-label
+                        class="text-subtitle-1 font-weight-semibold text-lightText ml-3"
+                        >{{ item.name }}</v-label>
+                      <v-label
+                        class="text-subtitle-1 text-lightText ml-3"
+                        >{{ item.nickname }}</v-label>
+                    </div>
+                  </div>
+                  <!-- ToDo: Implement remove volunteer action -->
+                  <v-btn v-if="!isMobile"
+                         size="small"
+                         color="error"
+                         class="ml-lg-auto"
+                         variant="outlined"
+                         icon="mdi-trash-can-outline" />
+                  <v-btn v-else 
+                         size="small"
+                         color="error"
+                         class="mt-4"
+                         variant="outlined">Remover voluntário</v-btn>
+                </v-card>
+              </div>
+              <p class="text-body-1" v-else>
+                <span>Nenhum voluntário confirmado.</span>
+              </p>
+            </div>
+          </v-window-item>
+
+          <v-window-item value="tab-3">
+            <div class="individual-container">
+              <p class="text-md-h3 mb-5">Coordenadores</p>
+              <div class="individual-card-container" v-if="event?.coordinators?.length">
+                <v-card class="individual-card border" elevation="0" v-for="item in event?.coordinators" :key="item.id">
+                  <div class="info-wrapper">
+                    <v-avatar v-if="!item.photo.includes('jpg') || !item.photo.includes('png')"
+                              size="50">
+                      <img src="@/assets/images/palhaco.png" alt="user" height="50" />
+                    </v-avatar>
+                    <v-avatar size="50" v-else>
+                      <img :src="item.photo" height="50" />
+                    </v-avatar>
+                    <div class="info-wrapper-name ml-2">
+                      <v-label
+                        class="text-subtitle-1 font-weight-semibold text-lightText ml-3"
+                        >{{ item.name }}</v-label>
+                      <v-label
+                        class="text-subtitle-1 text-lightText ml-3"
+                        >{{ item.nickname }}</v-label>
+                    </div>
+                  </div>
+                  <!-- ToDo: Implement goto coordinator profile -->
+                  <v-btn v-if="!isMobile"
+                         size="small"
+                         color="primary"
+                         class="ml-lg-auto"
+                         variant="outlined"
+                         icon="mdi-card-account-details-outline" />
+                  <v-btn v-else 
+                         size="small"
+                         color="primary"
+                         class="mt-4"
+                         variant="outlined">Remover voluntário</v-btn>
+                </v-card>
+              </div>
+              <p class="text-body-1" v-else>
+                Nenhum coordenador associado a este evento.
+              </p>
+            </div>
+          </v-window-item>
+        </v-window>
+      </div>
+    </UiParentCard>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.outlined-card {
+  display: flex;
+  flex-direction: column;
+  border-color: rgba(var(--v-border-color), var(--v-border-opacity));
+  border-style: solid;
+  border-width: thin;
+}
+
+.icon-label {
+  display: flex;
+  align-items: center;
+}
+
+.description-container {
+  padding: 20px 12px;
+  display: flex;
+  align-items: center;
+  @media (max-width: 960px) {
+    flex-direction: column;
+    gap: 30px;
+    padding: 40px 12px;
+  }
+}
+
+.description-name-container {
+  display: flex;
+  flex-basis: 33%;
+  flex-direction: column;
+  align-items: center;
+}
+
+.description-details-container {
+  display: flex;
+  flex-basis: 33%;
+  align-items: center;
+  justify-content: space-evenly;
+  &__item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-width: 50px;
+  }
+}
+
+.description-actions-container {
+  display: flex;
+  flex-basis: 33%;
+  flex-direction: column;
+  align-items: end;
+}
+
+.tabs-container {
+  display: flex;
+  background-color: rgb(var(--v-theme-grey100));
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+  &.mobile {
+    align-items: center;
+    justify-content: center;
+  }
+}
+.individual-container {
+  padding: 20px;
+}
+.individual-card-container {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+  @media (max-width: 1200px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  @media (max-width: 960px) {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .individual-card {
+    display: flex;
+    align-items: center;
+    padding: 20px;
+    @media (max-width: 1500px) {
+      flex-direction: column;
+    }
+  }
+  .info-wrapper {
+    display: flex;
+    align-items: center;
+    &-name {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+  }
+}
+:deep(.v-tab__slider) {
+  height: 0;
+}
+</style>


### PR DESCRIPTION
Pull request summary:
Rework upon Event Details	
    - Added custom component, a variation of Tabs component where content is displayed on a separate element while keeping the Tabbing dynamics;
    - Created another Event Detail component. This one's exclusive to display the new Details screen, keeping the old Detail component. This one is still being used
for create Event form;
    - Suggested different icons for Day and Time on the event details initial card (please confirm);
    - Unable to use the suggested icon for status. Used a simmilar one since the requested was not available on MDI (used this as a reference https://pictogrammers.com/library/mdi/)
    
![Screenshot 2024-09-15 202547](https://github.com/user-attachments/assets/4da73e10-b5fe-4e71-a0cc-e2159bf10a0b)
![Screenshot 2024-09-15 202712](https://github.com/user-attachments/assets/43a1c85f-c3f8-42c0-bb24-87e844ff36bb)
![Screenshot 2024-09-15 202738](https://github.com/user-attachments/assets/21de9a98-f3ad-4f4a-b536-66f3c440ee77)
![Screenshot 2024-09-15 202814](https://github.com/user-attachments/assets/da538c4f-88b4-445b-a23e-17cbb212bd6c)
![Screenshot 2024-09-15 202843](https://github.com/user-attachments/assets/18668113-bd93-48b1-8aee-5141ec203f91)
