### PR TITLE
feat: adds changes to new event detail page

### DIFF
--- a/src/components/modals/ConfirmParticipationModal.vue
+++ b/src/components/modals/ConfirmParticipationModal.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import type { event } from "@/entities/event";
+import { useEvents } from "@/stores/eventStore";
+import { eventDate, eventHour } from "@/utils/event";
+import { computed, onMounted, reactive, type PropType } from "vue";
+
+const eventStore = useEvents();
+
+const props = defineProps({
+  dialog: {
+    type: Boolean,
+    default: false,
+  },
+  mobileView: {
+    type: Boolean,
+    default: false,
+  },
+  event: {
+    type: Object as PropType<event> | any,
+    required: true,
+  },
+});
+
+const data = reactive({
+  isSubmitDisabled: true,
+  showSnackBar: false,
+  hasError: false,
+  timeRemaining: 5,
+})
+
+const emit = defineEmits(['closeConfirmParticipationModal']);
+
+const actionConfirmParticipation = async () => {
+  data.hasError = false;
+  try {
+    await eventStore.confirmVacancy();
+    closeModal(true, true);
+  } catch (error) {
+    data.hasError = true;
+    closeModal(false, true);
+  }
+}
+
+const closeModal = (reload = false, showSnackBar = false) => {
+  emit('closeConfirmParticipationModal', { reload, snackBar: { color: snackBarBtnColor.value, message: snackBarFeedbackLabel.value, show: showSnackBar  } });
+}
+
+const timeRemaningLabel = computed(() => {
+  return `Confirme em ${data.timeRemaining} segundos...`;
+})
+
+const snackBarFeedbackLabel = computed(() => {
+  return data.hasError ? 'Ocorreu um erro ao confirmar a sua participação.' : 'Participação confirmada com sucesso!';
+})
+
+const snackBarBtnColor = computed(() => {
+  return data.hasError ? 'error' : 'success';
+})
+
+const lockTimer = () => {
+  const lockTimer = setInterval(() => {
+    if(data.timeRemaining <= 1){
+      clearInterval(lockTimer);
+      data.isSubmitDisabled = false;
+    }
+    data.timeRemaining -= 1;
+  }, 1000);
+}
+
+onMounted(async () => {
+  lockTimer();
+});
+</script>
+
+<template>
+    <v-dialog 
+      v-model="props.dialog"
+      :fullscreen="props.mobileView"
+      persistent
+      transition="dialog-bottom-transition"
+      class="dialog-mw">
+      <v-card>
+        <v-toolbar dark color="primary" style="flex: unset">
+          <v-toolbar-title>Confirmação de presença</v-toolbar-title>
+          <v-btn icon color="inherit" @click="closeModal(false, false)" flat>
+            <XIcon  width="20" />
+          </v-btn>
+        </v-toolbar>
+          <v-card-text>
+            <p class="icon-label text-body-1 mb-2">
+              <span class="text-body-1 font-weight-bold">Local:</span>
+              <span class="text-body-1 ml-2">{{ event.address }} - {{ event.city }}</span>
+            </p>
+            <div class="mb-2 d-flex align-md-end">
+              <span class="text-body-1 font-weight-bold">Dia:</span>
+              <p class="text-md-h1 ml-4">{{ eventDate(event.happenAt)}}</p>
+            </div>
+            <div class="mb-2 d-flex align-md-end">
+              <span class="text-body-1 font-weight-bold">Hora:</span>
+              <p class="text-md-h1 ml-2">{{ eventHour(event.happenAt)}}</p>
+            </div>
+          </v-card-text>
+          <v-card-text>Você tem certeza que irá comparecer?</v-card-text>
+
+          <v-card-actions class="pa-6">
+            <v-spacer></v-spacer>
+            <v-btn color="green darken-1" variant="text" @click="closeModal(false, false)" flat>
+              Cancelar
+            </v-btn>
+            <v-btn @click="actionConfirmParticipation"
+                   :disabled="data.isSubmitDisabled || data.hasError"
+                   color="primary" 
+                   variant="tonal"
+                   type="submit" >
+              {{ data.isSubmitDisabled ? timeRemaningLabel : 'Confirmar' }}
+            </v-btn>
+          </v-card-actions>
+      </v-card>
+    </v-dialog>
+</template>
+
+<style lang="scss" scoped>
+:deep(.v-card-actions) {
+  padding: 10px 0 0;
+}
+</style>

--- a/src/components/modals/ConfirmRemoveParticipantModal.vue
+++ b/src/components/modals/ConfirmRemoveParticipantModal.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import type { event } from "@/entities/event";
+import { type PropType } from "vue";
+
+const props = defineProps({
+  dialog: {
+    type: Boolean,
+    default: false,
+  },
+  mobileView: {
+    type: Boolean,
+    default: false,
+  },
+  volunteer: {
+    type: Object as PropType<event> | any,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['closeConfirmRemoveParticipantModal']);
+
+const actionConfirmRemove = async () => {
+  closeModal(true);
+}
+
+const closeModal = (confirm = false) => {
+  emit('closeConfirmRemoveParticipantModal', { confirm });
+}
+</script>
+
+<template>
+    <v-dialog 
+      v-model="props.dialog"
+      :fullscreen="props.mobileView"
+      persistent
+      transition="dialog-bottom-transition"
+      class="dialog-mw">
+      <v-card>
+        <v-toolbar dark color="error" style="flex: unset">
+          <v-toolbar-title>Remover voluntário confirmado</v-toolbar-title>
+          <v-btn icon color="inherit" @click="closeModal(false)" flat>
+            <XIcon  width="20" />
+          </v-btn>
+        </v-toolbar>
+          <v-card-text>Você tem certeza que deseja remover a pessoa voluntária <span class="font-weight-bold">{{ volunteer.name }}</span> deste evento?</v-card-text>
+
+          <v-card-actions class="pa-6">
+            <v-spacer></v-spacer>
+            <v-btn color="green darken-1" variant="text" @click="closeModal(false)" flat>
+              Cancelar
+            </v-btn>
+            <v-btn @click="actionConfirmRemove"
+                   color="error" 
+                   variant="tonal"
+                   type="submit" >
+              Remover
+            </v-btn>
+          </v-card-actions>
+      </v-card>
+    </v-dialog>
+</template>
+
+<style lang="scss" scoped>
+:deep(.v-card-actions) {
+  padding: 10px 0 0;
+}
+</style>

--- a/src/components/tables/volunteersTable.vue
+++ b/src/components/tables/volunteersTable.vue
@@ -18,7 +18,6 @@ export default defineComponent({
     });
 
     const users = computed(() => store.getList);
-    console.log(users);
     return {
       users,
     };

--- a/src/entities/event.ts
+++ b/src/entities/event.ts
@@ -9,11 +9,22 @@ export interface event {
   date: string;
   time: string;
   occupancy: number;
+  capacity: number;
+  presences: Array<eventVolunteerResponse>;
+  coordinators: Array<eventVolunteerResponse>;
+  status: number;
+}
+
+export interface eventVolunteerResponse {
+  id: number;
+  volunteer: eventVolunteers;
 }
 
 export interface eventVolunteers {
   id: number;
+  accountId: string;
   name: string;
+  nickname: string;
   photo: string;
 }
 

--- a/src/interfaces/event.ts
+++ b/src/interfaces/event.ts
@@ -1,0 +1,5 @@
+export enum EventDateStatusTypes {
+    DUE = 'due',
+    ALMOST_DUE = 'almost_due',
+    CLOSED = 'closed',
+}

--- a/src/interfaces/permissions.ts
+++ b/src/interfaces/permissions.ts
@@ -1,0 +1,5 @@
+export enum UserPermissionTypes {
+    ADMINISTRATIVE = 'administrative',
+    OPERATIONAL = 'operational',
+    VOLUNTEER = 'volunteer',
+}

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview Compilation of methods that helps display event info.
+ */
+
+import type { event } from "@/entities/event";
+import { EventDateStatusTypes } from "@/interfaces/event";
+
+/**
+ * This method returns a string value based on the event status.
+ *
+ * @param status A number value that reflects to the event status.
+ * @returns string value for each status 1-Agendado, 2-Realizado 3-Cancelado. Defaults to an empty string.
+ */
+export const getStatusDescription = (status: number): string => {
+    switch (status) {
+        case 1:
+            return 'Agendado'
+        case 2:
+            return 'Realizado';
+        case 3:
+            return 'Cancelado';
+        default:
+            return '';
+    }
+}
+
+/**
+ * This method returns a boolean conditioned to the existence of a string value for volunteer avatar.
+ *
+ * @param photo A string value containing an image path with jpg or png format.
+ * @returns true if photo string value exists and the value contains an image path with .jpg or .png format. Otherwise, returns false.
+ */
+export const isUserAvatarAvailable = (photo: string): boolean => {
+    return !!(photo && (photo.includes('jpg') || photo.includes('png')))
+}
+
+/**
+ * This method returns a formated string containing the date of the event on dd/mm format.
+ *
+ * @param date A Date string value containing an event Date and Time.
+ * @returns A string value in the format of a dd/mm date.
+ */
+export const eventDate = (date: Date | string): string => {
+    if (!date) return '';
+    const newDate = new Date(date)
+    let dd = newDate.getDate();
+    let mm = newDate.getMonth() + 1;
+    let dayOfMonth = dd < 10 ? `0${dd}` : dd.toString();
+    let month = mm < 10 ? `0${mm}` : mm.toString();
+    return `${dayOfMonth}/${month}`
+}
+
+/**
+ * This method returns a formated string containing the hour of the event on hh:mm format.
+ *
+ * @param date A Date string value containing an event Date and Time.
+ * @returns A string value in the format of a hh:mm time.
+*/ 
+export const eventHour = (date: Date | string): string => {
+    if (!date) return '';
+    const newHour = new Date(date)
+    let hh = newHour.getHours();
+    let mm = newHour.getMinutes();
+    let hours = hh < 10 ? `0${hh}` : hh.toString();
+    let minutes = mm < 10 ? `0${mm}` : mm.toString();
+    return `${hours}:${minutes}`
+}
+
+/**
+ * Returns a string to display the status of the event based on the date.
+ *
+ * @param date Date or string date to be checked
+ * @returns string value for each event status due, almost_due, closed.
+*/ 
+export const eventDateStatus = (date: Date | string): EventDateStatusTypes | string => {
+    if (!date) return '';
+    let diffTime = Math.floor(new Date(date).valueOf() - new Date().valueOf());
+    let days = diffTime / (24*60*60*1000);
+    if (days > 1) {
+        return EventDateStatusTypes.DUE
+    } else if(days < 1 && days > 0) {
+        return EventDateStatusTypes.ALMOST_DUE
+    } else {
+        // if 'hours' value is negative, most likely the event has been already closed.
+        // the rule is defined on the FE but, an event that have a date greater than today, should not be listed on the dashboard
+        // while having the status 2 or 3.
+        return EventDateStatusTypes.CLOSED
+    }
+}
+
+/**
+ * Returns a boolean conditioned on the difference between occupancy and capacity.
+ * 
+ * @param event Event to be checked
+ * @returns true if the event capacity is lower than event.occupancy.
+ */
+export const isEventFull = (event: event): boolean => {
+    return event.capacity === 0;
+}

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Compilation of methods that handles action permissions for the current user.
+ */
+
+import type { eventVolunteerResponse } from "@/entities/event";
+import { UserPermissionTypes } from "@/interfaces/permissions";
+import { useAuthStore } from "@/stores/auth";
+
+const authStore = useAuthStore();
+
+/**
+ * This method returns a boolean conditioned on the existence of admin role on user permissions.
+ *
+ * @returns true if 'administrative' value exists and the user permissions.
+ */
+export const isCurrentUserAdministrative = (): boolean => {
+    const user = authStore.user;
+    if (!user) return false;
+    return user.permissions.includes(UserPermissionTypes.ADMINISTRATIVE)
+}
+
+/**
+ * This method returns a boolean conditioned on the existence of admin role on user permissions.
+ *
+ * @returns true if 'operational' value exists and the user permissions.
+ */
+export const isCurrentUserOperational = (): boolean => {
+    const user = authStore.user;
+    if (!user) return false;
+    return user.permissions.includes(UserPermissionTypes.OPERATIONAL)
+}
+
+/**
+ * Returns a boolean conditioned on the existence of the volunteer.id of the current user on a given presences array.
+ * 
+ * @param presences Array of presences of the event to be checked
+ * @returns true if the volunteer.id of the current user value exists on the given presences list.
+ */
+export const isCurrentUserPresentOnEvent = (presences: Array<eventVolunteerResponse>): boolean => {
+    const user = authStore.user;
+    if (!user) return false;
+    return !!presences.find((p) => p.volunteer.id === user.volunteer.id);
+}
+
+/**
+ * Returns a boolean that checks if the current user is the provided volunteer, by id.
+ * 
+ * @param volunteer provided volunteer to be checked on the user
+ * @returns true if the volunteer.id of the current user equals the id of the provided volunteer.
+ */
+export const isCurrentUserTheVolunteer = (id: string): boolean => {
+    const user = authStore.user;
+    if (!user || !id) return false;
+    return user.volunteer.id === id;
+}


### PR DESCRIPTION
Pull request summary:
- Creation of ConfirmParticipationModal new component that might be used as sample for future modals with proper adaptations;
- Added refactoring for the event entity - added missing properties and updated volunteersPresent state property;
- Fixed `event-presence` request by replacing user.id for volunteer.id accordingly with the latest BE updates;
- Fixed request `getById` on the eventStore - avoiding fetching multiple requests while getting event data;
- Added frontend rule to avoid confirm participation on a event, if current volunteer has already confirmed;
- Added several validations and increments to new EventDetail screen to attend the incoming features;
- Added new remove volunteer method within eventStore (removeParticipant); 
- Creation of ConfirmRemoveParticipantModal;
- Implemented remove volunteer feature;
- Implemented go to volunteer profile feature;
- Added documentation for some new util methods available;

![image](https://github.com/user-attachments/assets/5c50f826-8d1b-4658-91f1-84e3bb01ecad)

![image](https://github.com/user-attachments/assets/19f88afe-e055-49c5-80e6-10ad20597d76)

![image](https://github.com/user-attachments/assets/e9ede01a-704e-4b8c-9aea-9df4b5e98bc0)

![image](https://github.com/user-attachments/assets/16b8d6dd-1623-422c-9eb9-4125552fb1fe)

![image](https://github.com/user-attachments/assets/b60137ee-aff2-499a-8630-13555ca40921)

