### PR TITLE
feat: adds changes to the event detail - part 3

### DIFF
--- a/src/components/modals/ValidatePresenceModal.vue
+++ b/src/components/modals/ValidatePresenceModal.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import { onMounted, reactive } from "vue";
+import IndividualCard from "@/components/shared/IndividualCard.vue";
+import { useEvents } from "@/stores/eventStore";
+
+const eventStore = useEvents();
+
+const { 
+  volunteersPresent: eventVolunteers,
+} = storeToRefs(eventStore);
+
+const props = defineProps({
+  dialog: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const data = reactive({
+  individualsToValidate: [] as Array<any>,
+})
+
+const emit = defineEmits(['closeValidatePresenceModal']);
+
+const actionConfirmPresence = async () => {
+  console.log('implement action save | confirmed volunteers:', data.individualsToValidate.filter((x) => x.volunteer.present ));
+  closeModal(true);
+}
+
+const closeModal = (confirm = false) => {
+  emit('closeValidatePresenceModal', { confirm });
+}
+
+const getActionBtnProps = () => {
+  return {
+    id: 0,
+    button: {
+      icon: ''
+    },
+    visible: false,
+  }
+}
+
+onMounted(() => {
+  data.individualsToValidate = eventVolunteers.value.map((volunteer: any) => {
+    return {
+      volunteer: {
+        ...volunteer,
+        present: true,
+      }
+    }
+  });
+});
+</script>
+
+<template>
+    <v-dialog 
+      v-model="props.dialog"
+      fullscreen
+      persistent
+      transition="dialog-bottom-transition"
+      class="dialog-mw">
+      <v-card>
+        <v-toolbar dark color="primary" style="flex: unset">
+          <v-btn icon color="inherit" @click="closeModal(false)" flat>
+            <XIcon  width="20" />
+          </v-btn>
+          <v-toolbar-title>Concluir Evento</v-toolbar-title>
+          <v-btn icon color="inherit" @click="actionConfirmPresence" flat>
+            Salvar
+          </v-btn>
+        </v-toolbar>
+        <v-card-text>
+
+          <p class="font-weight-bold mt-10 mb-10">Confirme quem esteve presente no evento</p>
+          <div class="individual-card-wrapper">
+            <div class="individual-card-container mb-5" v-for="(individual, index) in data.individualsToValidate" :key="index">
+              <v-checkbox v-model="individual.volunteer.present" color="primary" :value="individual.volunteer.attented" hide-details />
+              <IndividualCard :key="individual.volunteer.id"
+                              :action="getActionBtnProps()"
+                              :individual="individual" />
+            </div>
+          </div>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
+</template>
+
+<style lang="scss" scoped>
+.individual-card-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+.individual-card-container {
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  align-items: center;
+}
+</style>

--- a/src/components/shared/ActionBar.vue
+++ b/src/components/shared/ActionBar.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { ActionButton } from '@/interfaces/event';
+
+defineProps({
+  menuIcon: {
+    type: String,
+    required: false,
+    default: () => 'mdi-dots-vertical'
+  },
+  actions: {
+    type: Array<ActionButton>,
+    required: true,
+  },
+});
+</script>
+
+<template>
+  <v-menu>
+    <template #activator="{ props }">
+      <v-btn :icon="menuIcon" variant="text" v-bind="props" />
+    </template>
+
+    <v-list>
+      <v-list-item v-for="(action, index) in actions" :key="index">
+        <v-btn
+            v-if="action.visible"
+            @click="action.onClick"
+            :prepend-icon="action.button.icon"
+            :size="action.button.size || 'small'"
+            :color="action.button.color || 'default'"
+            :variant="action.button.variant || 'text'"
+            :disabled="action.disabled"
+            :to="action.link ? { name: action.link.name, params: action.link.params } : null"
+            flat>{{ action.label }}</v-btn>  
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>

--- a/src/components/shared/IndividualCard.vue
+++ b/src/components/shared/IndividualCard.vue
@@ -18,7 +18,7 @@ defineProps({
 <template>
   <v-card class="individual-card border" elevation="0">
     <div class="info-wrapper">
-      <v-avatar size="50" v-if="isUserAvatarAvailable(individual.volunteer.photo)">
+      <v-avatar size="50" v-if="isUserAvatarAvailable(individual.volunteer?.photo)">
         <img :src="individual.volunteer.photo" height="50" />
       </v-avatar>
       <v-avatar size="50" v-else>
@@ -33,7 +33,7 @@ defineProps({
           >{{ individual.volunteer.nickname }}</v-label>
       </div>
     </div>
-    <div class="ml-lg-auto" >
+    <div class="ml-auto" >
       <v-tooltip activator="parent" location="top" v-if="action.tooltip">{{action.tooltip}}</v-tooltip>
       <v-btn
         v-if="action.visible"
@@ -42,7 +42,6 @@ defineProps({
         :size="action.button.size || 'small'"
         :color="action.button.color || 'default'"
         :variant="action.button.variant || 'text'"
-        class="ml-lg-auto"
         :disabled="action.disabled"
         :to="action.link ? { name: action.link.name, params: action.link.params } : null" />  
     </div>
@@ -52,11 +51,9 @@ defineProps({
 <style lang="scss" scoped>
 .individual-card {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  justify-content: space-between;
   padding: 20px;
-  @media (max-width: 1500px) {
-    flex-direction: column;
-  }
 }
 .info-wrapper {
   display: flex;

--- a/src/components/shared/IndividualCard.vue
+++ b/src/components/shared/IndividualCard.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { isUserAvatarAvailable } from "@/utils/event";
+import type { ActionButton } from '@/interfaces/event';
+import type { PropType } from "vue";
+
+defineProps({
+  action: {
+    type: Object as PropType<ActionButton>,
+    required: true,
+  },
+  individual: {
+    type: Object,
+    required: true,
+  },
+});
+</script>
+
+<template>
+  <v-card class="individual-card border" elevation="0">
+    <div class="info-wrapper">
+      <v-avatar size="50" v-if="isUserAvatarAvailable(individual.volunteer.photo)">
+        <img :src="individual.volunteer.photo" height="50" />
+      </v-avatar>
+      <v-avatar size="50" v-else>
+        <img src="@/assets/images/palhaco.png" alt="user" height="50" />
+      </v-avatar>
+      <div class="info-wrapper-name ml-2">
+        <v-label
+          class="text-subtitle-1 font-weight-semibold text-lightText ml-3"
+          >{{ individual.volunteer.name }}</v-label>
+        <v-label
+          class="text-subtitle-1 text-lightText ml-3"
+          >{{ individual.volunteer.nickname }}</v-label>
+      </div>
+    </div>
+    <div class="ml-lg-auto" >
+      <v-tooltip activator="parent" location="top" v-if="action.tooltip">{{action.tooltip}}</v-tooltip>
+      <v-btn
+        v-if="action.visible"
+        @click="action.onClick"
+        :icon="action.button.icon"
+        :size="action.button.size || 'small'"
+        :color="action.button.color || 'default'"
+        :variant="action.button.variant || 'text'"
+        class="ml-lg-auto"
+        :disabled="action.disabled"
+        :to="action.link ? { name: action.link.name, params: action.link.params } : null" />  
+    </div>
+  </v-card>
+</template>
+
+<style lang="scss" scoped>
+.individual-card {
+  display: flex;
+  align-items: center;
+  padding: 20px;
+  @media (max-width: 1500px) {
+    flex-direction: column;
+  }
+}
+.info-wrapper {
+  display: flex;
+  align-items: center;
+  &-name {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/src/interfaces/event.ts
+++ b/src/interfaces/event.ts
@@ -3,3 +3,27 @@ export enum EventDateStatusTypes {
     ALMOST_DUE = 'almost_due',
     CLOSED = 'closed',
 }
+
+export interface ButtonProps {
+    size?: string;
+    color?: string;
+    variant?: string;
+    icon: string;
+}
+
+export interface RouterLinkProps {
+    name: string;
+    params: Record<string, any>;
+}
+
+export interface ActionButton {
+    id: number;
+    label?: string;
+    button: ButtonProps;
+    link?: RouterLinkProps;
+    visible?: boolean;
+    disabled?: boolean;
+    tooltip?: boolean;
+    tooltipLabel?: string;
+    onClick?: () => Promise<void> | void | null;
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -115,7 +115,7 @@ export class Api implements ApiInterface {
         console.log(response);
       })
       .catch(function (error) {
-        console.log(error);
+        throw new Error(error);
       });
   }
   async put<T = any>(url: string, request: T): Promise<void> {
@@ -130,7 +130,7 @@ export class Api implements ApiInterface {
         console.log(response);
       })
       .catch(function (error) {
-        console.log(error);
+        throw new Error(error);
       });
   }
 

--- a/src/stores/eventStore.ts
+++ b/src/stores/eventStore.ts
@@ -223,6 +223,17 @@ export const useEvents = defineStore("events", () => {
     state.isLoading = false;
   };
 
+  const finishEvent = async (presences: Array<string>) => {
+    state.isLoading = true;
+    try {
+      await repository.finish(state.event.id, { presences });
+      state.isLoading = false;
+    } catch (e) {
+      state.isLoading = false;
+      throw new Error('Unable to finish event')
+    }
+  };
+
   const selectOther = (selected: boolean) => {
     state.isOtherSelecteced = selected;
 
@@ -248,10 +259,11 @@ export const useEvents = defineStore("events", () => {
     state.isLoading = true;
     try { 
       await presenceRepository.delete(volunteer.presenceId);
+      state.isLoading = false;
     } catch (e) {
+      state.isLoading = false;
       throw new Error(`error while removing pariticipant => ${e}`);
     }
-    state.isLoading = false;
   }
 
   const saveVonlunteers = async () => {
@@ -352,6 +364,7 @@ export const useEvents = defineStore("events", () => {
     save,
     changeVolunteer,
     finish,
+    finishEvent,
     CreateNewEvent,
     showModel,
     showModelRemove,

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -2,8 +2,10 @@
  * @fileoverview Compilation of methods that helps display event info.
  */
 
+
 import type { event } from "@/entities/event";
-import { EventDateStatusTypes } from "@/interfaces/event";
+import { EventDateStatusTypes, type ActionButton } from "@/interfaces/event";
+import { useEvents } from "@/stores/eventStore";
 
 /**
  * This method returns a string value based on the event status.
@@ -96,4 +98,36 @@ export const eventDateStatus = (date: Date | string): EventDateStatusTypes | str
  */
 export const isEventFull = (event: event): boolean => {
     return event.capacity === 0;
+}
+
+/**
+ * Returns a boolean conditioned on the difference between occupancy and capacity.
+ * 
+ * @param event Event to be checked
+ * @returns true if the event capacity is lower than event.occupancy.
+ */
+export const eventActions = (): Array<ActionButton> => {
+    const currentEvent = useEvents().getEvent;
+    return [
+        {
+            id: 0,
+            label: 'Editar',
+            button: {
+                icon: 'mdi-pencil'
+            },
+            link: {
+                name: 'DetailtEvent',
+                params: { id: currentEvent?.id }
+            },
+            visible: true,
+        },
+        {
+            id: 1,
+            label: 'Concluir',
+            button: {
+                icon: 'mdi-check-circle-outline'
+            },
+            visible: true,
+        },
+    ]
 }

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -31,6 +31,18 @@ export const isCurrentUserOperational = (): boolean => {
 }
 
 /**
+ * This method returns a boolean conditioned on the existence of admin role on user permissions.
+ *
+ * @returns true if 'operational' value exists and the user permissions.
+ */
+export const isCurrentUserAllowedToManage = (eventCoordinators: Array<eventVolunteerResponse>): boolean => {
+    const user = authStore.user;
+    if (!user) return false;
+    return user.permissions.includes(UserPermissionTypes.OPERATIONAL) && 
+        !!eventCoordinators.find((c) => c.volunteer.id === user.volunteer.id)
+}
+
+/**
  * Returns a boolean conditioned on the existence of the volunteer.id of the current user on a given presences array.
  * 
  * @param presences Array of presences of the event to be checked

--- a/src/views/events/EventDetails.vue
+++ b/src/views/events/EventDetails.vue
@@ -182,8 +182,9 @@ const showValidatePresenceDialog = () => {
   data.displayValidatePresenceModal = true;
 }
 
-const hideValidatePresenceDialog = () => {
+const hideValidatePresenceDialog = ({ snackBar } : { snackBar: SnackBarProps}) => {
   data.displayValidatePresenceModal = false;
+  data.snackBar = snackBar;
 }
 
 const setWindowWidth = () => {
@@ -480,23 +481,6 @@ onUnmounted(async () => {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }
   
-}
-.individual-card {
-  display: flex;
-  align-items: center;
-  padding: 20px;
-  @media (max-width: 1500px) {
-    flex-direction: column;
-  }
-}
-.info-wrapper {
-  display: flex;
-  align-items: center;
-  &-name {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-  }
 }
 :deep(.v-tab__slider) {
   height: 0;

--- a/src/views/events/EventDetails.vue
+++ b/src/views/events/EventDetails.vue
@@ -5,10 +5,13 @@ import { storeToRefs } from 'pinia';
 import { useEvents } from "@/stores/eventStore";
 import ConfirmParticipationModal from "@/components/modals/ConfirmParticipationModal.vue";
 import ConfirmRemoveParticipantModal from "@/components/modals/ConfirmRemoveParticipantModal.vue";
+import ValidatePresenceModal from "@/components/modals/ValidatePresenceModal.vue";
 import UiParentCard from "@/components/shared/UiParentCard.vue";
-import { eventDate, eventHour, getStatusDescription, isUserAvatarAvailable, eventDateStatus, isEventFull } from "@/utils/event";
-import { isCurrentUserAdministrative, isCurrentUserPresentOnEvent, isCurrentUserTheVolunteer } from "@/utils/permissions";
-import { EventDateStatusTypes } from "@/interfaces/event";
+import ActionBar from "@/components/shared/ActionBar.vue";
+import IndividualCard from "@/components/shared/IndividualCard.vue";
+import { eventDate, eventHour, getStatusDescription, eventDateStatus, isEventFull, eventActions } from "@/utils/event";
+import { isCurrentUserAdministrative, isCurrentUserAllowedToManage, isCurrentUserPresentOnEvent, isCurrentUserTheVolunteer } from "@/utils/permissions";
+import { EventDateStatusTypes, type ActionButton } from "@/interfaces/event";
 import type { event } from "@/entities/event";
 
 const router = useRouter();
@@ -33,6 +36,7 @@ interface EventDetailsDataProps {
   tab: string;
   displayConfirmParticipationModal: boolean;
   displayConfirmRemoveParticipantModal: boolean;
+  displayValidatePresenceModal: boolean;
   participantToRemove: any;
   snackBar: SnackBarProps;
 }
@@ -41,6 +45,7 @@ const data: EventDetailsDataProps = reactive({
   tab: 'tab-1',
   displayConfirmParticipationModal: false,
   displayConfirmRemoveParticipantModal: false,
+  displayValidatePresenceModal: false,
   participantToRemove: null,
   snackBar: {
     color: '',
@@ -78,24 +83,47 @@ const isEventOccupancyFull = computed(() => {
 })
 
 const shouldDisableConfirmParicipationBtn = computed((): boolean => {
-  if(!event.value) return true;
-  return isCurrentUserPresent.value || isEventOccupancyFull.value;
+  if (!event.value) return true;
+  return isCurrentUserPresent.value || isEventOccupancyFull.value || isEventClosed.value;
 })
 
+const disabledConfirmParicipationBtnTooltip = computed((): string => {
+  if (isEventClosed.value) return 'Este evento já aconteceu.';
+  else if (isCurrentUserPresent.value) return 'Você já confirmou participação neste evento.';
+  else if (isEventOccupancyFull.value) return 'Todas as vagas já foram preenchidas.';
+  return '';
+});
+
 const shouldDisplayRemoveVolunteerBtn = (volunteerId: string) => {
+  if (!event.value) return false;
   const isAdmin = isCurrentUserAdministrative();
-  if ( isEventClosed.value) return false;
-  else if (isAdmin && isCurrentUserTheVolunteer(volunteerId)) return false;
+  const isOperational = isCurrentUserAllowedToManage(event.value?.coordinators)
+  // Hide Remove Volunteer btn if the user have confirmed
+  // even if the user is administrative or operational
+  if ((isAdmin || isOperational) && isCurrentUserTheVolunteer(volunteerId)) return false;
+  // Hide Remove Volunteer btn if the event has your date in the past or have been closed.
+  else if (isEventClosed.value) return false;
+  // Show Remove Volunteer btn if the user has administrative privileges.
   else if (isAdmin) return true;
+  // Show Remove Volunteer btn if the user is not administrative, but has operational privileges.
+  else if (isOperational) return true;
   return false;
 }
+
+const shouldDisplayMenu = computed((): boolean => {
+  if (!event.value) return false;
+  const isAdmin = isCurrentUserAdministrative();
+  const isOperational = isCurrentUserAllowedToManage(event.value?.coordinators)
+  return (isAdmin || isOperational);
+});
 
 const confirmedVolunteersList = computed((): Array<any> => {
   if(!eventVolunteers.value.length) return [];
   return eventVolunteers.value.map((x: any) => {
     return {
-      ...x,
-      actionRemoveVisible: shouldDisplayRemoveVolunteerBtn(x.id),
+      volunteer: {
+        ...x,
+      }
     }
   });
 })
@@ -103,6 +131,60 @@ const confirmedVolunteersList = computed((): Array<any> => {
 const tabsDirection = computed((): string => {
   return isMobile.value ? 'vertical' : 'horizontal'
 });
+
+const menuActions = computed((): Array<ActionButton> => {
+  const actions = eventActions();
+  return actions.map((action) => {
+    return {
+      ...action,
+      ...(action.id === 0 ? { onClick: eventStore.edit } : {}),
+      ...(action.id === 1 ? { 
+        onClick: showValidatePresenceDialog,
+        disabled: isEventClosed.value,
+      } : {})
+    }
+  });
+});
+
+const getVolunteerIndividualAction = (individual: any) => {
+  return {
+    id: 0,
+    button: {
+      icon: 'mdi-trash-can-outline',
+      variant: 'outlined',
+      color: 'error'
+    },
+    disabled: isEventAlmostDue.value,
+    tooltip: isEventAlmostDue.value,
+    visible: shouldDisplayRemoveVolunteerBtn(individual.volunteer.id),
+    tooltipLabel: 'Não é possivel remover o voluntário pois o evento inicia em breve.',
+    onClick: () => showConfirmRemoveParticipantDialog(individual)
+  }
+}
+
+const getCoordinatorIndividualAction = (individual: any) => {
+  return {
+    id: 0,
+    button: {
+      icon: 'mdi-card-account-details-outline',
+      variant: 'outlined',
+      color: 'primary'
+    },
+    visible: true,
+    link: {
+      name: 'DetailtUser',
+      params: { id: individual.volunteer.id }
+    },
+  }
+}
+
+const showValidatePresenceDialog = () => {
+  data.displayValidatePresenceModal = true;
+}
+
+const hideValidatePresenceDialog = () => {
+  data.displayValidatePresenceModal = false;
+}
 
 const setWindowWidth = () => {
   width.value = window.innerWidth;
@@ -117,6 +199,8 @@ const hideConfirmParticipationDialog = ({ reload, snackBar }: { reload: boolean 
   data.snackBar = snackBar;
   if (reload) {
     loadEvent();
+    // if confirmation success, force focus on confirmed volunteers tab
+    data.tab = 'tab-2';
   }
 }
 
@@ -130,7 +214,7 @@ const removeParticipant = async (participant: any) => {
 
 const showConfirmRemoveParticipantDialog = (participant: any): void => {
   data.displayConfirmRemoveParticipantModal = true;
-  data.participantToRemove = participant;
+  data.participantToRemove = participant.volunteer;
 }
 
 const hideConfirmRemoveParticipantDialog = async ({ confirm }: { confirm: boolean }): Promise<void> => {
@@ -156,7 +240,10 @@ onUnmounted(async () => {
   <div class="event-details-view">
     <div v-if="isLoading" class="loading" />
     <UiParentCard title="Eventos">
-      <div class="rounded-md outlined-card">
+      <template v-slot:action v-if="shouldDisplayMenu">
+        <ActionBar :actions="menuActions" />
+      </template>
+      <div class="rounded-md border">
         <div class="description-tab">
           <div class="description-container">
             <div class="description-name-container">
@@ -203,8 +290,11 @@ onUnmounted(async () => {
                        @click="showConfirmParticipationDialog">
                   Participar
                 </v-btn>
-                <v-tooltip activator="parent" location="top" v-if="isCurrentUserPresent">Você já confirmou participação neste evento.</v-tooltip>
-                <v-tooltip activator="parent" location="top" v-else-if="isEventOccupancyFull">Todas as vagas já foram preenchidas.</v-tooltip>
+                <v-tooltip v-if="shouldDisableConfirmParicipationBtn"
+                           activator="parent"
+                           location="top">
+                  {{disabledConfirmParicipationBtnTooltip}}
+                </v-tooltip>
               </div>
             </div>
 
@@ -225,7 +315,7 @@ onUnmounted(async () => {
         </div>
       </div>
 
-      <div class="mt-5 rounded-md outlined-card">
+      <div class="mt-5 rounded-md border">
         <v-window v-model="data.tab" class="rounded-md">
           <v-window-item value="tab-1">
             <v-card flat>
@@ -257,41 +347,10 @@ onUnmounted(async () => {
             <div class="individual-container">
               <p class="text-md-h3 mb-5">Confirmados</p>
               <div class="individual-card-container" v-if="eventVolunteers.length">
-                <v-card class="individual-card border" elevation="0" v-for="volunteer in confirmedVolunteersList" :key="volunteer.id">
-                  <div class="info-wrapper">
-                    <v-avatar size="50" v-if="isUserAvatarAvailable(volunteer.photo)">
-                      <img :src="volunteer.photo" height="50" />
-                    </v-avatar>
-                    <v-avatar size="50" v-else>
-                      <img src="@/assets/images/palhaco.png" alt="user" height="50" />
-                    </v-avatar>
-                    <div class="info-wrapper-name ml-2">
-                      <v-label
-                        class="text-subtitle-1 font-weight-semibold text-lightText ml-3"
-                        >{{ volunteer.name }}</v-label>
-                      <v-label
-                        class="text-subtitle-1 text-lightText ml-3"
-                        >{{ volunteer.nickname }}</v-label>
-                    </div>
-                  </div>
-                  <div class="ml-lg-auto" v-if="volunteer.actionRemoveVisible">
-                    <v-tooltip activator="parent" location="top" v-if="isEventAlmostDue">Não é possivel remover o voluntário pois o evento inicia em breve.</v-tooltip>
-                    <v-btn v-if="!isMobile"
-                          size="small"
-                          color="error"
-                          variant="outlined"
-                          :disabled="isEventAlmostDue"
-                          @click="showConfirmRemoveParticipantDialog(volunteer)"
-                          icon="mdi-trash-can-outline" />
-                    <v-btn v-else 
-                          size="small"
-                          color="error"
-                          class="mt-4"
-                          :disabled="isEventAlmostDue"
-                          @click="showConfirmRemoveParticipantDialog(volunteer)"
-                          variant="outlined">Remover voluntário</v-btn>
-                  </div>
-                </v-card>
+                <IndividualCard v-for="individual in confirmedVolunteersList" 
+                                :key="individual.id"
+                                :action="getVolunteerIndividualAction(individual)"
+                                :individual="individual"  />
               </div>
               <p class="text-body-1" v-else>
                 <span>Nenhum voluntário confirmado.</span>
@@ -303,32 +362,10 @@ onUnmounted(async () => {
             <div class="individual-container">
               <p class="text-md-h3 mb-5">Coordenadores</p>
               <div class="individual-card-container" v-if="event?.coordinators?.length">
-                <v-card class="individual-card border" elevation="0" v-for="coordinator in event?.coordinators" :key="coordinator.id">
-                  <div class="info-wrapper">
-                    <v-avatar size="50" v-if="isUserAvatarAvailable(coordinator.volunteer.photo)">
-                      <img :src="coordinator.volunteer.photo" height="50" />
-                    </v-avatar>
-                    <v-avatar size="50" v-else>
-                      <img src="@/assets/images/palhaco.png" alt="user" height="50" />
-                    </v-avatar>
-                    <div class="info-wrapper-name ml-2">
-                      <v-label
-                        class="text-subtitle-1 font-weight-semibold text-lightText ml-3"
-                        >{{ coordinator.volunteer.name }}</v-label>
-                      <v-label
-                        class="text-subtitle-1 text-lightText ml-3"
-                        >{{ coordinator.volunteer.nickname }}</v-label>
-                    </div>
-                  </div>
-                  <router-link tag="v-btn"
-                               class="ml-lg-auto"
-                               :to="{ name: 'DetailtUser', params: { id: coordinator.volunteer.id } }">
-                    <v-btn size="small"
-                          color="primary"
-                          variant="outlined"
-                          icon="mdi-card-account-details-outline" />
-                  </router-link>
-                </v-card>
+                <IndividualCard v-for="individual in event?.coordinators" 
+                                :key="individual.id"
+                                :action="getCoordinatorIndividualAction(individual)"
+                                :individual="individual"  />
               </div>
               <p class="text-body-1" v-else>
                 Nenhum coordenador associado a este evento.
@@ -355,6 +392,12 @@ onUnmounted(async () => {
       :dialog="data.displayConfirmRemoveParticipantModal"
       @closeConfirmRemoveParticipantModal="hideConfirmRemoveParticipantDialog" />
 
+    <!-- Modal Validate Volunteers Presence -->
+    <ValidatePresenceModal
+      v-if="data.displayValidatePresenceModal"
+      :dialog="data.displayValidatePresenceModal"
+      @closeValidatePresenceModal="hideValidatePresenceDialog" />
+
     <!-- Feedback SnackBar -->
     <v-snackbar v-model="data.snackBar.show">
       {{ data.snackBar.message }}
@@ -370,14 +413,6 @@ onUnmounted(async () => {
 </template>
 
 <style lang="scss" scoped>
-.outlined-card {
-  display: flex;
-  flex-direction: column;
-  border-color: rgba(var(--v-border-color), var(--v-border-opacity));
-  border-style: solid;
-  border-width: thin;
-}
-
 .icon-label {
   display: flex;
   align-items: center;
@@ -444,22 +479,23 @@ onUnmounted(async () => {
   @media (max-width: 960px) {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }
-  .individual-card {
-    display: flex;
-    align-items: center;
-    padding: 20px;
-    @media (max-width: 1500px) {
-      flex-direction: column;
-    }
+  
+}
+.individual-card {
+  display: flex;
+  align-items: center;
+  padding: 20px;
+  @media (max-width: 1500px) {
+    flex-direction: column;
   }
-  .info-wrapper {
+}
+.info-wrapper {
+  display: flex;
+  align-items: center;
+  &-name {
     display: flex;
-    align-items: center;
-    &-name {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-    }
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 :deep(.v-tab__slider) {


### PR DESCRIPTION
Pull request summary:
- Creation of ConfirmParticipationModal new component that might be used as sample for future modals with proper adaptations;
- Added refactoring for the event entity - added missing properties and updated volunteersPresent state property;
- Fixed `event-presence` request by replacing user.id for volunteer.id accordingly with the latest BE updates;
- Fixed request `getById` on the eventStore - avoiding fetching multiple requests while getting event data;
- Added frontend rule to avoid confirm participation on a event, if current volunteer has already confirmed;
- Added several validations and increments to new EventDetail screen to attend the incoming features;
- Added new remove volunteer method within eventStore (removeParticipant); 
- Creation of ConfirmRemoveParticipantModal;
- Implemented remove volunteer feature;
- Implemented go to volunteer profile feature;
- Added documentation for some new methods available;
- Missing part 2 Operational integrated rules implementation;
- Part 3 implementation [ Dinamic side menu] ;
- Refactoring/fixing event presences request

![image](https://github.com/user-attachments/assets/e1937416-94d5-4150-80fa-462a2c648906)

![image](https://github.com/user-attachments/assets/6ab1a5d2-e702-4bff-bec5-b990b9e5915d)

![image](https://github.com/user-attachments/assets/e8bb3b6a-1607-427a-9e43-0ab84e1c2b28)

![image](https://github.com/user-attachments/assets/0a0a1f2b-da8f-4029-a8a8-002971c9f66e)

