### PR TITLE
feat: adds adjustments to event details + delete feature

### DIFF
--- a/src/components/modals/ConfirmDeleteEventModal.vue
+++ b/src/components/modals/ConfirmDeleteEventModal.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import type { event } from "@/entities/event";
+import { useEvents } from "@/stores/eventStore";
+import { useSnackBar } from "@/stores/snackBarStore";
+import { storeToRefs } from "pinia";
+import { computed, reactive } from "vue";
+
+const eventStore = useEvents();
+const snackBarStore = useSnackBar()
+
+const {
+  getEvent: event,
+  volunteersPresent: eventVolunteers,
+} = storeToRefs(eventStore);
+
+const props = defineProps({
+  dialog: {
+    type: Boolean,
+    default: false,
+  },
+  mobileView: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['closeConfirmDeleteEventModal']);
+
+const data = reactive({
+  hasError: false,
+})
+
+const actionConfirmDelete = async () => {
+  data.hasError = false;
+  try {
+    await eventStore.deleteSingleEvent(event.value as event);
+    closeModal(true);
+  } catch (error) {
+    data.hasError = true;
+    closeModal(false);
+  }
+  snackBarStore.addToQueue({ 
+    color: snackBarBtnColor.value, 
+    message: snackBarFeedbackLabel.value
+  });
+}
+
+const snackBarFeedbackLabel = computed(() => {
+  const name = event.value?.name;
+  return data.hasError ? 'Ocorreu um erro ao deletar o evento.' : `Evento ${name} deletado com sucesso.`;
+})
+
+const snackBarBtnColor = computed(() => {
+  return data.hasError ? 'error' : 'success';
+})
+
+const closeModal = (confirm = false) => {
+  emit('closeConfirmDeleteEventModal', { confirm });
+}
+</script>
+
+<template>
+    <v-dialog 
+      v-model="props.dialog"
+      :fullscreen="props.mobileView"
+      persistent
+      transition="dialog-bottom-transition"
+      class="dialog-mw">
+      <v-card>
+        <v-toolbar dark color="error" style="flex: unset">
+          <v-toolbar-title>Deletar evento</v-toolbar-title>
+          <v-btn icon color="inherit" @click="closeModal(false)" flat>
+            <XIcon  width="20" />
+          </v-btn>
+        </v-toolbar>
+          <v-card-text>Você tem certeza que deseja deletar o evento <span class="font-weight-bold">{{ event?.name }}</span>?</v-card-text>
+          <v-card-text v-if="eventVolunteers.length">
+            <v-icon color="warning" class="mr-1">mdi-alert</v-icon>
+            Este evento possui <span class="font-weight-bold">
+            {{ eventVolunteers.length }} {{ eventVolunteers.length > 1 ? 'voluntários confirmados' : 'voluntário confirmado' }}
+          </span>.</v-card-text>
+
+          <v-card-actions class="pa-6">
+            <v-spacer></v-spacer>
+            <v-btn color="green darken-1" variant="text" @click="closeModal(false)" flat>
+              Cancelar
+            </v-btn>
+            <v-btn @click="actionConfirmDelete"
+                   color="error" 
+                   variant="tonal"
+                   type="submit" >
+              Deletar
+            </v-btn>
+          </v-card-actions>
+      </v-card>
+    </v-dialog>
+</template>
+
+<style lang="scss" scoped>
+:deep(.v-card-actions) {
+  padding: 10px 0 0;
+}
+</style>

--- a/src/components/modals/ConfirmParticipationModal.vue
+++ b/src/components/modals/ConfirmParticipationModal.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import type { event } from "@/entities/event";
 import { useEvents } from "@/stores/eventStore";
+import { useSnackBar } from "@/stores/snackBarStore";
 import { eventDate, eventHour } from "@/utils/event";
 import { computed, onMounted, reactive, type PropType } from "vue";
 
 const eventStore = useEvents();
+const snackBarStore = useSnackBar()
 
 const props = defineProps({
   dialog: {
@@ -23,7 +25,6 @@ const props = defineProps({
 
 const data = reactive({
   isSubmitDisabled: true,
-  showSnackBar: false,
   hasError: false,
   timeRemaining: 5,
 })
@@ -34,15 +35,19 @@ const actionConfirmParticipation = async () => {
   data.hasError = false;
   try {
     await eventStore.confirmVacancy();
-    closeModal(true, true);
+    closeModal(true);
   } catch (error) {
     data.hasError = true;
-    closeModal(false, true);
+    closeModal(false);
   }
+  snackBarStore.addToQueue({ 
+    color: snackBarBtnColor.value, 
+    message: snackBarFeedbackLabel.value
+  });
 }
 
-const closeModal = (reload = false, showSnackBar = false) => {
-  emit('closeConfirmParticipationModal', { reload, snackBar: { color: snackBarBtnColor.value, message: snackBarFeedbackLabel.value, show: showSnackBar  } });
+const closeModal = (reload = false) => {
+  emit('closeConfirmParticipationModal', { reload });
 }
 
 const timeRemaningLabel = computed(() => {
@@ -82,7 +87,7 @@ onMounted(async () => {
       <v-card>
         <v-toolbar dark color="primary" style="flex: unset">
           <v-toolbar-title>Confirmação de presença</v-toolbar-title>
-          <v-btn icon color="inherit" @click="closeModal(false, false)" flat>
+          <v-btn icon color="inherit" @click="closeModal(false)" flat>
             <XIcon  width="20" />
           </v-btn>
         </v-toolbar>
@@ -104,7 +109,7 @@ onMounted(async () => {
 
           <v-card-actions class="pa-6">
             <v-spacer></v-spacer>
-            <v-btn color="green darken-1" variant="text" @click="closeModal(false, false)" flat>
+            <v-btn color="green darken-1" variant="text" @click="closeModal(false)" flat>
               Cancelar
             </v-btn>
             <v-btn @click="actionConfirmParticipation"

--- a/src/components/modals/ValidatePresenceModal.vue
+++ b/src/components/modals/ValidatePresenceModal.vue
@@ -3,8 +3,10 @@ import { storeToRefs } from "pinia";
 import { computed, onMounted, reactive } from "vue";
 import IndividualCard from "@/components/shared/IndividualCard.vue";
 import { useEvents } from "@/stores/eventStore";
+import { useSnackBar } from "@/stores/snackBarStore";
 
 const eventStore = useEvents();
+const snackBarStore = useSnackBar();
 
 const { 
   volunteersPresent: eventVolunteers,
@@ -32,7 +34,11 @@ const actionConfirmPresence = async () => {
   } catch (error) {
     data.hasError = true;
   }
-  closeModal(true);
+  closeModal();
+  snackBarStore.addToQueue({ 
+    color: snackBarBtnColor.value, 
+    message: snackBarFeedbackLabel.value
+  });
 }
 
 const snackBarFeedbackLabel = computed(() => {
@@ -43,8 +49,8 @@ const snackBarBtnColor = computed(() => {
   return data.hasError ? 'error' : 'success';
 })
 
-const closeModal = (showSnackBar = false) => {
-  emit('closeValidatePresenceModal', { snackBar: { color: snackBarBtnColor.value, message: snackBarFeedbackLabel.value, show: showSnackBar  } });
+const closeModal = () => {
+  emit('closeValidatePresenceModal');
 }
 
 const getActionBtnProps = () => {
@@ -78,7 +84,7 @@ onMounted(() => {
       class="dialog-mw">
       <v-card>
         <v-toolbar dark color="primary" style="flex: unset">
-          <v-btn icon color="inherit" @click="closeModal(false)" flat>
+          <v-btn icon color="inherit" @click="closeModal()" flat>
             <XIcon  width="20" />
           </v-btn>
           <v-toolbar-title>Concluir Evento</v-toolbar-title>

--- a/src/components/shared/SnackBar.vue
+++ b/src/components/shared/SnackBar.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import type { SnackBar } from "@/interfaces/components";
+import { useSnackBar } from "@/stores/snackBarStore";
+import { storeToRefs } from "pinia";
+import { computed, reactive, watch, type PropType } from "vue";
+
+const snackBarStore = useSnackBar()
+
+const {
+  defaultTimeout,
+} = storeToRefs(snackBarStore);
+
+const props = defineProps({
+  snackBar: { 
+    type: Object as PropType<SnackBar> | any,
+    required: true,
+    default: () => {
+      return {}
+    }
+  },
+  show: {
+    type: Boolean,
+  },
+  defaultTimeout: {
+    type: Number,
+  }
+});
+
+const timeout = computed(() => {
+  if (!props.snackBar.message) return 0;
+  const t = props.snackBar.timeout || defaultTimeout.value
+  return props.snackBar.timeout || props.defaultTimeout;
+})
+
+const data = reactive({
+  showSnackbar: false,
+})
+
+const dismissSnackBar = () => {
+  data.showSnackbar = false;
+}
+
+watch(
+  [() => props.snackBar],
+  ([snackBar]) => {
+    if(snackBar.message) {
+      data.showSnackbar = true;
+      setTimeout(() => {
+        data.showSnackbar = false;
+      }, timeout.value - 400); // 400 ms refers to the snackbar fadeout animation time.
+    }
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+    <v-snackbar v-model="data.showSnackbar" :timeout="timeout" elevation="24">
+      {{ snackBar.message }}
+      <template v-slot:actions>
+        <v-btn :color="snackBar.color || 'default'"
+               :variant="snackBar.variant || 'text'"
+               @click="snackBar.action ? snackBar.action() : dismissSnackBar()">
+          {{ snackBar.actionLabel ? snackBar.actionLabel : 'Fechar'  }}
+        </v-btn>
+      </template>
+    </v-snackbar>
+</template>

--- a/src/components/shared/SnackBarContainer.vue
+++ b/src/components/shared/SnackBarContainer.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { SnackBar } from "@/interfaces/components";
+import { computed, type PropType } from "vue";
+import SnackBarComponent from "@/components/shared/SnackBar.vue";
+
+import { useSnackBar } from "@/stores/snackBarStore";
+import { storeToRefs } from "pinia";
+
+const snackBarStore = useSnackBar()
+
+const { 
+  currentSnackBar,
+  defaultTimeout,
+} = storeToRefs(snackBarStore);
+</script>
+
+<template>
+  <div class="snackbar-container">
+    <SnackBarComponent :snackBar="currentSnackBar"
+                       :defaultTimeout="defaultTimeout"/>
+  </div>
+</template>

--- a/src/components/shared/UiParentCard.vue
+++ b/src/components/shared/UiParentCard.vue
@@ -9,7 +9,7 @@ Card||=============================== //
 <template>
   <v-card elevation="10">
     <v-card-item class="py-4 px-6">
-      <div class="d-sm-flex align-center justify-space-between">
+      <div class="d-flex align-center justify-space-between">
         <v-card-title class="text-h5">{{ title }}</v-card-title>
         <!-- <template v-slot:append> -->
         <slot name="action"></slot>

--- a/src/interfaces/components.ts
+++ b/src/interfaces/components.ts
@@ -1,0 +1,16 @@
+export interface SnackBar {
+	color?: string;
+	message: string;
+	variant?: string;
+	timeout?: number;
+	show?: boolean;
+	action?: Function;
+	actionLabel?: string;
+}
+  
+export interface SnackBarState {
+	queue: Array<SnackBar>;
+	busy: boolean;
+	defaultTimeout: number;
+	interval: any;
+}

--- a/src/layouts/full/FullLayout.vue
+++ b/src/layouts/full/FullLayout.vue
@@ -7,6 +7,9 @@ import HorizontalSidebar from "./horizontal-sidebar/HorizontalSidebar.vue";
 import Customizer from "./customizer/Customizer.vue";
 import { useCustomizerStore } from "../../stores/customizer";
 import { pl, zhHans } from "vuetify/locale";
+
+import SnackBarContainer from "@/components/shared/SnackBarContainer.vue";
+
 const customizer = useCustomizerStore();
 </script>
 
@@ -109,4 +112,5 @@ const customizer = useCustomizerStore();
       </v-main>
     </v-app>
   </v-locale-provider>
+  <SnackBarContainer />
 </template>

--- a/src/stores/eventStore.ts
+++ b/src/stores/eventStore.ts
@@ -336,6 +336,19 @@ export const useEvents = defineStore("events", () => {
 
     state.showModelRemove = false;
   };
+
+  const deleteSingleEvent = async (event: event) => {
+    if (!event) return;
+    state.isLoading = true;
+    try { 
+      await repository.delete(event.id);
+      state.isLoading = false;
+    } catch (e) {
+      state.isLoading = false;
+      throw new Error(`error while deleting event => ${event.name}`);
+    }
+  };
+
   const openModalRemove = async (event: event) => {
     state.event = event;
     state.showModelRemove = true;
@@ -379,5 +392,6 @@ export const useEvents = defineStore("events", () => {
     volunteersPresent,
     runProcess,
     remove,
+    deleteSingleEvent,
   };
 });

--- a/src/stores/snackBarStore.ts
+++ b/src/stores/snackBarStore.ts
@@ -1,0 +1,41 @@
+import type { SnackBar, SnackBarState } from "@/interfaces/components";
+import { defineStore } from "pinia";
+
+export const useSnackBar = defineStore('snackBarStore', {
+  state: (): SnackBarState => ({
+    queue: [],
+    busy: false,
+    defaultTimeout: 3000,
+    interval: null,
+  }),
+  getters: {
+    shouldDisplaySnackBar(): boolean {
+      return !!this.queue.length;
+    },
+    currentSnackBar(): SnackBar | undefined {
+      return this.queue[0];
+    },
+    timeout(): number {
+      return this.currentSnackBar?.timeout || this.defaultTimeout;
+    }
+  },
+  actions: {
+    addToQueue(snackBar: SnackBar): void {
+      if (!snackBar) return;
+      this.queue.push(snackBar);
+      if (!this.busy) {
+        this.showSnackBar();
+      }
+    },
+    showSnackBar(): void {
+      this.busy = true;
+      this.interval = setInterval(() => {
+        if (this.queue.length === 1) {
+          clearInterval(this.interval);
+          this.busy = false;
+        }
+        this.queue.splice(0, 1);
+      }, this.timeout);
+    },
+  },
+});

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -125,7 +125,16 @@ export const eventActions = (): Array<ActionButton> => {
             id: 1,
             label: 'Concluir',
             button: {
-                icon: 'mdi-check-circle-outline'
+                icon: 'mdi-check-circle-outline',
+            },
+            visible: true,
+        },
+        {
+            id: 2,
+            label: 'Deletar',
+            button: {
+                icon: 'mdi-trash-can-outline',
+                color: 'error'
             },
             visible: true,
         },

--- a/src/views/events/EventDetails.vue
+++ b/src/views/events/EventDetails.vue
@@ -6,6 +6,7 @@ import { useEvents } from "@/stores/eventStore";
 import ConfirmParticipationModal from "@/components/modals/ConfirmParticipationModal.vue";
 import ConfirmRemoveParticipantModal from "@/components/modals/ConfirmRemoveParticipantModal.vue";
 import ValidatePresenceModal from "@/components/modals/ValidatePresenceModal.vue";
+import ConfirmDeleteEventModal from "@/components/modals/ConfirmDeleteEventModal.vue";
 import UiParentCard from "@/components/shared/UiParentCard.vue";
 import ActionBar from "@/components/shared/ActionBar.vue";
 import IndividualCard from "@/components/shared/IndividualCard.vue";
@@ -37,6 +38,7 @@ interface EventDetailsDataProps {
   displayConfirmParticipationModal: boolean;
   displayConfirmRemoveParticipantModal: boolean;
   displayValidatePresenceModal: boolean;
+  displayConfirmDeleteEventModal: boolean;
   participantToRemove: any;
   snackBar: SnackBarProps;
 }
@@ -46,6 +48,7 @@ const data: EventDetailsDataProps = reactive({
   displayConfirmParticipationModal: false,
   displayConfirmRemoveParticipantModal: false,
   displayValidatePresenceModal: false,
+  displayConfirmDeleteEventModal: false,
   participantToRemove: null,
   snackBar: {
     color: '',
@@ -140,7 +143,9 @@ const menuActions = computed((): Array<ActionButton> => {
       ...(action.id === 0 ? { onClick: eventStore.edit } : {}),
       ...(action.id === 1 ? { 
         onClick: showValidatePresenceDialog,
-        disabled: isEventClosed.value,
+      } : {}),
+      ...(action.id === 2 ? { 
+        onClick: showConfirmDeleteEventDialog,
       } : {})
     }
   });
@@ -182,9 +187,20 @@ const showValidatePresenceDialog = () => {
   data.displayValidatePresenceModal = true;
 }
 
-const hideValidatePresenceDialog = ({ snackBar } : { snackBar: SnackBarProps}) => {
+const hideValidatePresenceDialog = () => {
   data.displayValidatePresenceModal = false;
-  data.snackBar = snackBar;
+  router.push({ name: "ListEvents" });
+}
+
+const showConfirmDeleteEventDialog = () => {
+  data.displayConfirmDeleteEventModal = true;
+}
+
+const hideConfirmDeleteEventDialog = ({ confirm }: { confirm: boolean }) => {
+  data.displayConfirmDeleteEventModal = false;
+  if (confirm) {
+    router.push({ name: "ListEvents" });
+  }
 }
 
 const setWindowWidth = () => {
@@ -195,9 +211,8 @@ const showConfirmParticipationDialog = () => {
   data.displayConfirmParticipationModal = true;
 }
 
-const hideConfirmParticipationDialog = ({ reload, snackBar }: { reload: boolean , snackBar: SnackBarProps}) => {
+const hideConfirmParticipationDialog = ({ reload }: { reload: boolean }) => {
   data.displayConfirmParticipationModal = false;
-  data.snackBar = snackBar;
   if (reload) {
     loadEvent();
     // if confirmation success, force focus on confirmed volunteers tab
@@ -376,6 +391,7 @@ onUnmounted(async () => {
         </v-window>
       </div>
     </UiParentCard>
+    
 
     <!-- Modal Confirm Participation -->
     <ConfirmParticipationModal
@@ -399,17 +415,12 @@ onUnmounted(async () => {
       :dialog="data.displayValidatePresenceModal"
       @closeValidatePresenceModal="hideValidatePresenceDialog" />
 
-    <!-- Feedback SnackBar -->
-    <v-snackbar v-model="data.snackBar.show">
-      {{ data.snackBar.message }}
-      <template v-slot:actions>
-        <v-btn :color="data.snackBar.color"
-                variant="text"
-                @click="data.snackBar.show = false">
-          Fechar
-        </v-btn>
-      </template>
-    </v-snackbar>
+    <!-- Modal Delete Event -->
+    <ConfirmDeleteEventModal
+      v-if="data.displayConfirmDeleteEventModal"
+      :mobileView="isMobile"
+      :dialog="data.displayConfirmDeleteEventModal"
+      @closeConfirmDeleteEventModal="hideConfirmDeleteEventDialog" />
   </div>
 </template>
 


### PR DESCRIPTION
 - Refactor snackbar and modals; 
	Needed because the snackbar component was previously nested within router-view components, once pushing navigation states, the snackbar could not be visible;
 - Added SnackBar queue ability; Now the SnackBars have a dedicated store and multiple notifications can be pushed simultaneously. They will respect their individual timeouts, and automatically be displayed individually, until the queue list becomes empty;
 - Removed logic that prevented finishing event with date on the past;
 - Fixed menu breaking layout on mobile devices;
 - Adjusted logic after finishing an event. Now after finishing an event the app navigates to the Events list;
 - Added Delete event Feature. Now it is possible to delete an event from the new Details screen menu;