### PR TITLE
feat: adds new event form

### DIFF
--- a/src/interfaces/repositories/eventRepositoryInterface.ts
+++ b/src/interfaces/repositories/eventRepositoryInterface.ts
@@ -1,14 +1,13 @@
 import type {
   event,
   eventsResponse,
-  eventResponse,
   finishEventRequest,
 } from "../../entities/event";
 
 //abstract
 export interface eventRepositoryInterface {
   getEvents(name: string): Promise<eventsResponse>;
-  getById(id: string): Promise<eventResponse>;
+  getById(id: string): Promise<event>;
 
   create(event: event): Promise<void>;
   update(event: event): Promise<void>;

--- a/src/repositories/eventRepository.ts
+++ b/src/repositories/eventRepository.ts
@@ -31,7 +31,7 @@ export class eventRepository implements eventRepositoryInterface {
     return response.data;
   }
 
-  public async getById(id: string): Promise<eventResponse> {
+  public async getById(id: string): Promise<event> {
     const response = await this.apiService.invoke("event/" + id);
     return response.data;
   }

--- a/src/router/eventsRoutes.ts
+++ b/src/router/eventsRoutes.ts
@@ -27,6 +27,11 @@ const eventsRoutes = {
       }
     },
     {
+      name: "EventForm",
+      path: "/events/form/:id?",
+      component: () => import("@/views/events/EventForm.vue"),
+    },
+    {
       name: "CreateEvent",
       path: "/events/Adicionar",
       component: () => import("@/views/events/Detail.vue"),

--- a/src/stores/eventStore.ts
+++ b/src/stores/eventStore.ts
@@ -24,7 +24,7 @@ interface eventState {
   isLoading: boolean;
   numberConfirmed: number;
   isOtherSelecteced: boolean;
-  volunteersPresent: [];
+  volunteersPresent: Array<any>;
   volunteersDeleted: [];
   volunteersConfirmed: finishEventRequest;
   action: string;
@@ -200,6 +200,21 @@ export const useEvents = defineStore("events", () => {
     state.isLoading = false;
   };
 
+  const createOrUpdate = async (event: any) => {
+    state.isLoading = true;
+    try {
+      if (!event.id) {
+        await repository.create(event);
+      } else {
+        await repository.update(event);
+      }
+    } catch (e) {
+      state.isLoading = false;
+      throw new Error(`Unable to ${event.id ? 'update' :  'create' } event`);
+    }
+    state.isLoading = false;
+  };
+
   const confirmVacancy = async () => {
     state.isLoading = true;
     state.showModel = false;
@@ -233,6 +248,24 @@ export const useEvents = defineStore("events", () => {
       throw new Error('Unable to finish event')
     }
   };
+
+  // cleaner and more readable fetch event method
+  const fetchEventById = async (id: string): Promise<void> => {
+    resetEvent();
+    state.isLoading = true;
+    try {
+      const data = await repository.getById(id);
+      state.event = data;
+      state.isLoading = false;
+    } catch (e) {
+      state.isLoading = false;
+      throw new Error('Failed fetching event');
+    }
+  };
+
+  const resetEvent = (): void => {
+    state.event = null;
+  }
 
   const selectOther = (selected: boolean) => {
     state.isOtherSelecteced = selected;
@@ -365,6 +398,9 @@ export const useEvents = defineStore("events", () => {
     clearFilters,
     getEvent,
     getById,
+    fetchEventById,
+    resetEvent,
+    createOrUpdate,
     getPlaces,
     isEditing,
     getNumberConfirmed,

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -116,7 +116,7 @@ export const eventActions = (): Array<ActionButton> => {
                 icon: 'mdi-pencil'
             },
             link: {
-                name: 'DetailtEvent',
+                name: 'EventForm',
                 params: { id: currentEvent?.id }
             },
             visible: true,

--- a/src/utils/form.ts
+++ b/src/utils/form.ts
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Compilation of form rules
+ */
+
+/**
+ * All rules for event form.
+ * 
+ * @returns object containing specific rules for event entity form.
+ */
+export const eventFormRules = (): Record<string, any> => {
+	return {
+		name: [
+			(v: string): string | boolean => !!v || 'Nome do evento é obrigatório!',
+		],
+		meetingPoint: [
+			(v: string): string | boolean => !!v || 'Ponto de encontro é obrigatório!',
+		],
+		address: [
+			(v: string): string | boolean => !!v || 'O Endereço é obrigatório!',
+		],
+		city: [
+			(v: string): string | boolean => !!v || 'A Cidade é obrigatória!',
+		],
+	}
+}

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -7,11 +7,19 @@ import eventsTableCustom from "@/components/tables/eventsTableCustom.vue";
 
 import { storeToRefs } from 'pinia';
 import { useEvents } from "@/stores/eventStore";
+import { useRouter } from "vue-router";
+
 
 const page = ref({ title: "Dashboard" });
 const DASHBOARD_NEXT_EVENTS_QUERY = `status=1&currentPage=1&pageSize=100`;
 
 const { isLoading } = storeToRefs(useEvents());
+
+// ToDo: Dev testing purpose - Remove before deploying to prod
+// const router = useRouter();
+// const gotoForm = () => {
+//   router.push({ name: 'EventForm'})
+// }
 
 onMounted(async () => {
   await useEvents().getDataByQuery(DASHBOARD_NEXT_EVENTS_QUERY);
@@ -20,6 +28,8 @@ onMounted(async () => {
 
 <template>
   <div class="dashboard-view">
+    <!-- ToDo: Dev testing purpose - Remove before deploying to prod -->
+    <!-- <v-btn @click="gotoForm">goto</v-btn> -->
     <BaseBreadcrumb
       :title="page.title"
     ></BaseBreadcrumb>

--- a/src/views/events/Detail.vue
+++ b/src/views/events/Detail.vue
@@ -231,6 +231,8 @@ export default defineComponent({
         <v-label class="text-subtitle-1 font-weight-semibold text-lightText"
           >Data:</v-label
         >
+
+        {{format(new Date())}}
         <VueDatePicker
           v-model="event.happenAt"
           :format="format"

--- a/src/views/events/EventDetails.vue
+++ b/src/views/events/EventDetails.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, onUnmounted, reactive, ref } from "vue";
 import { useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { useEvents } from "@/stores/eventStore";
+import BaseBreadcrumb from "@/components/shared/BaseBreadcrumb.vue";
 import ConfirmParticipationModal from "@/components/modals/ConfirmParticipationModal.vue";
 import ConfirmRemoveParticipantModal from "@/components/modals/ConfirmRemoveParticipantModal.vue";
 import ValidatePresenceModal from "@/components/modals/ValidatePresenceModal.vue";
@@ -27,12 +28,6 @@ const {
 
 const currentRoute = router.currentRoute.value;
 
-interface SnackBarProps {
-  color: string;
-  message: string;
-  show: boolean;
-}
-
 interface EventDetailsDataProps {
   tab: string;
   displayConfirmParticipationModal: boolean;
@@ -40,7 +35,6 @@ interface EventDetailsDataProps {
   displayValidatePresenceModal: boolean;
   displayConfirmDeleteEventModal: boolean;
   participantToRemove: any;
-  snackBar: SnackBarProps;
 }
 
 const data: EventDetailsDataProps = reactive({
@@ -50,14 +44,21 @@ const data: EventDetailsDataProps = reactive({
   displayValidatePresenceModal: false,
   displayConfirmDeleteEventModal: false,
   participantToRemove: null,
-  snackBar: {
-    color: '',
-    message: '',
-    show: false,
-  }
 })
 
 const width = ref(window.innerWidth)
+
+const breadcrumbs = ref([
+	{
+    text: "Eventos",
+    disabled: false,
+    to: "/events",
+	},
+	{
+    text: "Detalhes",
+    disabled: true,
+	},
+]);
 
 const isMobile = computed(() => {
   return width.value < 960;
@@ -255,7 +256,11 @@ onUnmounted(async () => {
 <template>
   <div class="event-details-view">
     <div v-if="isLoading" class="loading" />
-    <UiParentCard title="Eventos">
+    <BaseBreadcrumb
+			:title="'Eventos'"
+			:breadcrumbs="breadcrumbs"
+    />
+    <UiParentCard title="Evento">
       <template v-slot:action v-if="shouldDisplayMenu">
         <ActionBar :actions="menuActions" />
       </template>

--- a/src/views/events/EventForm.vue
+++ b/src/views/events/EventForm.vue
@@ -1,0 +1,346 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, reactive, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import BaseBreadcrumb from "@/components/shared/BaseBreadcrumb.vue";
+import type { event } from "@/entities/event";
+import { useEvents } from "@/stores/eventStore";
+import { storeToRefs } from "pinia";
+import { useSnackBar } from "@/stores/snackBarStore";
+import { eventFormRules } from "@/utils/form";
+
+const router = useRouter();
+const route = useRoute();
+const eventStore = useEvents();
+const snackBarStore = useSnackBar()
+
+const {
+  getEvent: event,
+} = storeToRefs(eventStore);
+
+interface EventFormProps {
+  tab: string;
+	loading: boolean;
+	eventModel: Record<string, any>;
+	formValid: boolean;
+}
+
+const data: EventFormProps = reactive({
+  tab: 'tab-1',
+	loading: false,
+	formValid: false,
+	eventModel: {
+		when: {
+			date: new Date(),
+			time: {
+				hours: 0,
+				minutes: 0,
+				seconds: 0
+			},
+		}
+	},
+})
+
+const isEdit = computed(() => {
+  return !!event.value?.id;
+})
+
+const breadcrumbs = ref([
+	{
+    text: "Eventos",
+    disabled: false,
+    to: "/events",
+	},
+	{
+	text: `${isEdit.value ? 'Edição' : 'Adição'}`,
+    disabled: true,
+	},
+]);
+
+const width = ref(window.innerWidth)
+
+
+
+const page = ref({ title: "Eventos" });
+const locale = ref('pt-BR');
+const formLabelClass = ref('text-subtitle-1 font-weight-semibold text-lightText mb-1');
+const formRef = ref();
+const rules = ref(eventFormRules());
+
+const isMobile = computed(() => {
+  return width.value < 960;
+})
+
+const tabsDirection = computed((): string => {
+  return isMobile.value ? 'vertical' : 'horizontal'
+});
+
+
+
+const setModelDate = (date: Date) => {
+	const eventDate = new Date(date);
+	data.eventModel.when.date = eventDate;
+	data.eventModel.when.time.hours = eventDate.getHours();
+	data.eventModel.when.time.minutes = eventDate.getMinutes();
+};
+
+const formatDate = (date: Date) => {
+	const day = date.getDate();
+	const month = (date.getMonth() + 1).toString().padStart(2, "0");
+	const year = date.getFullYear();
+
+	return `${day}/${month}/${year}`;
+};
+
+const formatTime = (date: Date) => {
+	const hours = date.getHours();
+	const minutes = (date.getMinutes() < 10 ? "0" : "") + date.getMinutes();
+
+	return `${hours}:${minutes}`;
+};
+
+const formattedDate = computed((): Date => {
+	const time = data.eventModel.when.time;
+	let date = new Date(data.eventModel.when.date)
+	date.setHours(time.hours, time.minutes, time.seconds);
+  return date;
+});
+
+const setEventModel = (event: event) => {
+	data.eventModel.name = event.name;
+	data.eventModel.description = event.description;
+	data.eventModel.meetingPoint = event.meetingPoint;
+	data.eventModel.occupancy = event.occupancy;
+	data.eventModel.address = event.address;
+	data.eventModel.city = event.city;
+	setModelDate(event.happenAt as Date);
+};
+
+const goBack = () => {
+	router.back();
+};
+
+const fetchEvent = async (): Promise<void> => {
+	data.loading = true;
+	try {
+		await eventStore.fetchEventById(route.params.id as string);
+	} catch (error) {
+		snackBarStore.addToQueue({ 
+			color: 'error', 
+			message: 'Não foi possível carregar o evento.'
+		});
+		goBack();
+	}
+	data.loading = false;
+}
+
+const prepareModelToSubmit = () => {
+	return {
+		...(isEdit.value ? { id: event.value?.id } : {}),
+		name: data.eventModel.name,
+		description: data.eventModel.description,
+		meetingPoint: data.eventModel.meetingPoint,
+		occupancy: data.eventModel.occupancy,
+		address: data.eventModel.address,
+		city: data.eventModel.city,
+		happenAt: formattedDate.value,
+		status: 1,
+	}
+};
+
+const submit = async (): Promise<void> => {
+	data.loading = true;
+	try {
+		const event = prepareModelToSubmit();
+		await eventStore.createOrUpdate(event);
+		router.push({ name: 'Dashboard' });
+	} catch (error) {
+		snackBarStore.addToQueue({ 
+			color: 'error', 
+			message: `Não foi possível ${isEdit.value ? 'atualizar' : 'criar' } o evento.`
+		});
+		goBack();
+	}
+	data.loading = false;
+}
+
+onMounted(async () => {
+  if (!!route.params.id) {
+		await fetchEvent();
+		try {
+			setEventModel(event.value as event);
+		} catch (error) {
+			snackBarStore.addToQueue({ 
+				color: 'error', 
+				message: 'Não foi possível recurerar os dados do evento.'
+			});
+			goBack();
+		}
+	}
+});
+
+onUnmounted(async () => {
+  eventStore.resetEvent();
+});
+</script>
+
+<template>
+  <div class="event-form">
+    <div v-if="data.loading" class="loading" />
+    <BaseBreadcrumb
+			:title="page.title"
+			:breadcrumbs="breadcrumbs"
+    />
+
+		<v-form v-model="data.formValid" 
+						class="form-container" 
+						ref="formRef" 
+						@submit.prevent="submit">
+			<div class="tabs-container">
+				<v-tabs
+					v-model="data.tab"
+					color="primary"
+					:direction="tabsDirection"
+				>
+					<v-tab text="Essenciais" value="tab-1" />
+					<v-tab text="Localidade" value="tab-2" />
+				</v-tabs>
+			</div>
+
+			<v-row class="mt-4">
+				<v-col cols="12" md="12">
+					<v-row>
+						<v-col cols="12" md="8">
+							<!-- Tab context cards -->
+							<v-window v-model="data.tab" class="rounded-md border">
+
+								<v-window-item value="tab-1">
+									<v-card title="Essenciais" elevation="0">
+										<v-card-text class="px-8">
+											<div class="form-property-data mb-4">
+												<v-text-field
+													v-model="data.eventModel.name"
+													label="Nome"
+													placeholder="Nome do evento"
+													:rules="rules.name"
+													required
+												></v-text-field>
+											</div>
+											<div class="form-property-data mb-4">
+												<v-text-field
+													v-model="data.eventModel.meetingPoint"
+													label="Ponto de encontro"
+													placeholder="Onde será o local de encontro?"
+													:rules="rules.meetingPoint"
+													required
+												></v-text-field>
+											</div>
+											<div class="form-property-data mb-4">
+												<v-text-field
+													v-model="data.eventModel.description"
+													label="Informação"
+													placeholder="Insira uma informação adicional sobre o evento"
+												></v-text-field>
+											</div>
+										</v-card-text>
+										<v-card-text class="px-8">
+
+										</v-card-text>
+									</v-card>
+								</v-window-item>
+
+								<v-window-item value="tab-2">
+									<v-row>
+										<v-col cols="12" md="12">
+											<v-card title="Localidade" elevation="0">
+												<v-card-text class="px-8">
+													<div class="form-property-data mb-4">
+														<v-text-field
+															v-model="data.eventModel.address"
+															label="Endereço"
+															placeholder="Av. Dezessete de Abril, 36 - Guajuviras"
+															:rules="rules.address"
+															required
+														></v-text-field>
+													</div>
+													<div class="form-property-data">
+														<v-text-field
+															v-model="data.eventModel.city"
+															label="Cidade"
+															placeholder="Canoas, RS"
+															:rules="rules.city"
+															required
+														></v-text-field>
+													</div>
+												</v-card-text>
+											</v-card>
+										</v-col>
+									</v-row>
+								</v-window-item>
+							</v-window>
+						</v-col>
+
+						<!-- Fixed cards -->
+						<v-col cols="12" md="4">
+							<v-row>
+								<v-col cols="12" md="12">
+									<v-card title="Quando" class="border mb-6" elevation="0" style="z-index: 1"> 
+										<v-card-text class="px-8">
+											<v-label :class="formLabelClass">Data</v-label>
+											<VueDatePicker
+												class="mb-5"
+												v-model="data.eventModel.when.date"
+												:locale="locale"
+												:format="formatDate"
+												:enable-time-picker="false"
+											/>
+											<v-label :class="formLabelClass">Horário</v-label>
+											<VueDatePicker
+												v-model="data.eventModel.when.time"
+												:locale="locale"
+												:format="formatTime"
+												time-picker
+											/>
+										</v-card-text>
+									</v-card>
+
+									<v-card title="Vagas" class="border mb-6" elevation="0" style="z-index: 0">
+										<v-card-text class="px-8">
+											<v-text-field
+												v-model="data.eventModel.occupancy"
+												type="number"
+												label="Vagas disponíveis"
+												placeholder="10"
+											></v-text-field>
+										</v-card-text>
+									</v-card>
+
+									<v-card class="border pt-4" elevation="0" style="z-index: 0">
+										<v-card-actions class="justify-end">
+											<v-btn color="error"
+														 variant="flat"
+														 size="large"
+														 width="100"
+														 @click="goBack">Cancelar</v-btn>
+											<v-btn color="primary" 
+														 variant="flat" 
+														 size="large" 
+														 class="ml-5" 
+														 width="100" 
+														 type="submit"
+														 :disabled="!data.formValid">
+											 {{ isEdit ? 'Atualizar' : 'Criar' }}
+											</v-btn>
+										</v-card-actions>
+									</v-card>
+									
+
+								</v-col>
+							</v-row>
+	
+						</v-col>
+					</v-row>
+				</v-col>
+			</v-row>
+		</v-form>
+  </div>
+</template>

--- a/src/views/volunteers/Detail.vue
+++ b/src/views/volunteers/Detail.vue
@@ -26,17 +26,16 @@ export default defineComponent({
       {
         text: "Dashboard",
         disabled: false,
-        href: "/",
+        to: "/dashboard",
       },
       {
         text: "Voluntários",
         disabled: false,
-        href: "/Voluntarios",
+        to: "/volunteers",
       },
       {
         text: "Detalhes",
         disabled: true,
-        href: "#",
       },
     ]);
     const route = useRoute();

--- a/src/views/volunteers/List.vue
+++ b/src/views/volunteers/List.vue
@@ -28,12 +28,11 @@ export default defineComponent({
       {
         text: "Dashboard",
         disabled: false,
-        href: "/",
+        to: "/dashboard",
       },
       {
         text: "Voluntários",
         disabled: true,
-        href: "#",
       },
     ]);
     const route = useRoute();


### PR DESCRIPTION
Pull request summary:
- Added Event create/edit form.
  New route;
  New form layout;
  Form fields validation;
  Date and Time fields are now splitted; 
 
 
 At this point there is no cta that leads to the event creation page. The create and edit page share the same component.
 just manually navigate to the create form by typing on the url `event/form` 
 
 
![image](https://github.com/user-attachments/assets/7390f7e4-fc1e-4e5d-a5b6-25fc9a7c19a1)
 
![image](https://github.com/user-attachments/assets/7b4e07da-2436-42ca-ae90-171884a10482)

![image](https://github.com/user-attachments/assets/7564795e-dd40-4bb8-beb0-59acac814901)

